### PR TITLE
Update blog.module.ts (fixing app breaking change)

### DIFF
--- a/src/app/blog/blog.module.ts
+++ b/src/app/blog/blog.module.ts
@@ -1,6 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { ComponentsModule } from '@scullyio/ng-lib';
+import { ScullyLibModule } from '@scullyio/ng-lib';
 import { BlogRoutingModule } from './blog-routing.module';
 import { BlogComponent } from './blog.component';
 import { BlogListComponent } from './blog-list/blog-list.component';
@@ -8,6 +8,6 @@ import { MaterialModule } from '../shared/material.module';
 
 @NgModule({
   declarations: [BlogComponent, BlogListComponent],
-  imports: [CommonModule, BlogRoutingModule, ComponentsModule, MaterialModule],
+  imports: [CommonModule, BlogRoutingModule, ScullyLibModule, MaterialModule],
 })
 export class BlogModule {}


### PR DESCRIPTION
ComponentsModule was changed to ScullyLibModule in a recent update